### PR TITLE
Added PrismJS syntax theme and details on how to change it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,22 @@ Hoping to get some help finishing out this site as well.
 
 1. Contribute your favorite patterns in Svelte with code examples
 2. Help build out this site
+
+### How to change the code editor theme
+
+The syntax highlighting is powered by [PrismJS](https://github.com/PrismJS) under the hood, and this project comes with a default theme of Visual Studio Code Dark+ by [tabuckner](https://github.com/tabuckner).
+
+You can find an availble list of PrismJS themes [here on GitHub.](https://github.com/PrismJS/prism-themes)
+
+In order to change the syntax highlighting theme for the project, just follow these steps.
+
+1. Go to the [PrismJS themes repo](https://github.com/PrismJS/prism-themes) and select the theme you want.
+2. Click on the name of the theme you wnat to use.
+3. Now that you are on the page showing the CSS for the theme, go ahead and click the "Raw" button.
+4. Now press `Cmd + A` or `Ctrl + A` to select all, and then press `Cmd + C` or `Ctrl + C` to copy all of the CSS.
+5. Create a new CSS file in the `~/static/prism-theme` folder, and name it whatever you would like.
+6. Using `Cmd/Ctrl + V` paste in the copied CSS of the Prism theme.
+7. Save the file.
+8. Open the file `~/src/app.html` and edit the `<link>` tag on line 6 so that it matches the name of your CSS file in the `~/static/prism-theme` folder. Then save the file.
+
+You should not have to restart the development server, the theme should just be updated client side.

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="/favicon.png" />
+		<link rel="stylesheet" href="/prism-theme/prism-vsc-dark-plus.css" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%svelte.head%
 	</head>

--- a/src/posts/keydown.md
+++ b/src/posts/keydown.md
@@ -9,7 +9,7 @@ date: 10/8/21
 
 Detecting keypress events is useful for creating webapps and websites that feel like native applications. The good news is Svelte makes it super easy to do this.
 
-```js
+```svelte
 <script>
   let keyPressed = ''
   function handleKeyUp(event) {

--- a/static/prism-theme/prism-vsc-dark-plus.css
+++ b/static/prism-theme/prism-vsc-dark-plus.css
@@ -1,0 +1,275 @@
+pre[class*='language-'],
+code[class*='language-'] {
+	color: #d4d4d4;
+	font-size: 13px;
+	text-shadow: none;
+	font-family: Menlo, Monaco, Consolas, 'Andale Mono', 'Ubuntu Mono', 'Courier New', monospace;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	line-height: 1.5;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+pre[class*='language-']::selection,
+code[class*='language-']::selection,
+pre[class*='language-'] *::selection,
+code[class*='language-'] *::selection {
+	text-shadow: none;
+	background: #264f78;
+}
+
+@media print {
+	pre[class*='language-'],
+	code[class*='language-'] {
+		text-shadow: none;
+	}
+}
+
+pre[class*='language-'] {
+	padding: 1em;
+	margin: 0.5em 0;
+	overflow: auto;
+	background: #1e1e1e;
+}
+
+:not(pre) > code[class*='language-'] {
+	padding: 0.1em 0.3em;
+	border-radius: 0.3em;
+	color: #db4c69;
+	background: #1e1e1e;
+}
+/*********************************************************
+* Tokens
+*/
+.namespace {
+	opacity: 0.7;
+}
+
+.token.doctype .token.doctype-tag {
+	color: #569cd6;
+}
+
+.token.doctype .token.name {
+	color: #9cdcfe;
+}
+
+.token.comment,
+.token.prolog {
+	color: #6a9955;
+}
+
+.token.punctuation,
+.language-html .language-css .token.punctuation,
+.language-html .language-javascript .token.punctuation {
+	color: #d4d4d4;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.inserted,
+.token.unit {
+	color: #b5cea8;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.deleted {
+	color: #ce9178;
+}
+
+.language-css .token.string.url {
+	text-decoration: underline;
+}
+
+.token.operator,
+.token.entity {
+	color: #d4d4d4;
+}
+
+.token.operator.arrow {
+	color: #569cd6;
+}
+
+.token.atrule {
+	color: #ce9178;
+}
+
+.token.atrule .token.rule {
+	color: #c586c0;
+}
+
+.token.atrule .token.url {
+	color: #9cdcfe;
+}
+
+.token.atrule .token.url .token.function {
+	color: #dcdcaa;
+}
+
+.token.atrule .token.url .token.punctuation {
+	color: #d4d4d4;
+}
+
+.token.keyword {
+	color: #569cd6;
+}
+
+.token.keyword.module,
+.token.keyword.control-flow {
+	color: #c586c0;
+}
+
+.token.function,
+.token.function .token.maybe-class-name {
+	color: #dcdcaa;
+}
+
+.token.regex {
+	color: #d16969;
+}
+
+.token.important {
+	color: #569cd6;
+}
+
+.token.italic {
+	font-style: italic;
+}
+
+.token.constant {
+	color: #9cdcfe;
+}
+
+.token.class-name,
+.token.maybe-class-name {
+	color: #4ec9b0;
+}
+
+.token.console {
+	color: #9cdcfe;
+}
+
+.token.parameter {
+	color: #9cdcfe;
+}
+
+.token.interpolation {
+	color: #9cdcfe;
+}
+
+.token.punctuation.interpolation-punctuation {
+	color: #569cd6;
+}
+
+.token.boolean {
+	color: #569cd6;
+}
+
+.token.property,
+.token.variable,
+.token.imports .token.maybe-class-name,
+.token.exports .token.maybe-class-name {
+	color: #9cdcfe;
+}
+
+.token.selector {
+	color: #d7ba7d;
+}
+
+.token.escape {
+	color: #d7ba7d;
+}
+
+.token.tag {
+	color: #569cd6;
+}
+
+.token.tag .token.punctuation {
+	color: #808080;
+}
+
+.token.cdata {
+	color: #808080;
+}
+
+.token.attr-name {
+	color: #9cdcfe;
+}
+
+.token.attr-value,
+.token.attr-value .token.punctuation {
+	color: #ce9178;
+}
+
+.token.attr-value .token.punctuation.attr-equals {
+	color: #d4d4d4;
+}
+
+.token.entity {
+	color: #569cd6;
+}
+
+.token.namespace {
+	color: #4ec9b0;
+}
+/*********************************************************
+* Language Specific
+*/
+
+pre[class*='language-javascript'],
+code[class*='language-javascript'],
+pre[class*='language-jsx'],
+code[class*='language-jsx'],
+pre[class*='language-typescript'],
+code[class*='language-typescript'],
+pre[class*='language-tsx'],
+code[class*='language-tsx'] {
+	color: #9cdcfe;
+}
+
+pre[class*='language-css'],
+code[class*='language-css'] {
+	color: #ce9178;
+}
+
+pre[class*='language-html'],
+code[class*='language-html'] {
+	color: #d4d4d4;
+}
+
+.language-regex .token.anchor {
+	color: #dcdcaa;
+}
+
+.language-html .token.punctuation {
+	color: #808080;
+}
+/*********************************************************
+* Line highlighting
+*/
+pre[class*='language-'] > code[class*='language-'] {
+	position: relative;
+	z-index: 1;
+}
+
+.line-highlight.line-highlight {
+	background: #f7ebc6;
+	box-shadow: inset 5px 0 0 #f7d87c;
+	z-index: 0;
+}


### PR DESCRIPTION
## Syntax Highlighting!!! 🎉  🥳 

The update turns on the PrismJS syntax highlighting by adding in a CSS file with the theme colors. 
I made a new folder `/syntax-themes` inside of `/static` to hold the themes for clarity. 

I have also added a section to the `README.md` file explaining step by step how to change the theme.
With links to where you get the themes from, of course 😉 
Basically you need to have a `<link>` tag pointing to the CSS file in `~/src.app.html`.

Let me know if you have any questions, or want anything changed 👍 